### PR TITLE
Fix AsyncService to actually work asynchronously

### DIFF
--- a/src/SyncVsAsync/Services/AsyncService.cs
+++ b/src/SyncVsAsync/Services/AsyncService.cs
@@ -33,11 +33,17 @@ namespace SyncVsAsync.Services
             if (searchResultsGrid == null) return result;
 
             var searchResultsLinks = GetSearchResultsLinks(searchResultsGrid);
+
+            var PageTasks = new List<Task<HtmlDocument>>();
+
             foreach (var linkUrl in searchResultsLinks)
             {
                 result.Add(linkUrl);
                 await LoadDocumentAsync(linkUrl);
+                PageTasks.Add(LoadDocumentAsync(linkUrl));
             }
+
+            Task.WaitAll(PageTasks.ToArray());
 
             return result;
         }


### PR DESCRIPTION
Original code awaited (waited for) each call to LoadDocumentAsync.  The service now makes all of the calls asynchronously, and then waits for them to all finish (via Task.WaitAll).